### PR TITLE
npm: Prevent sporadic build issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "debug": "^2.2.0",
     "nan": "^2.10.0",
-    "node-pre-gyp": "0.6.x"
+    "node-pre-gyp": "^0.12.0"
   },
   "optionalDependencies": {
     "usb": "^1.1.0"


### PR DESCRIPTION
Might be caused by parallel jobs?

```
> @abandonware/bluetooth-hci-socket@0.5.3-0 install /local/home/philippe/var/cache/url/git/ssh/github.com/tizenteam/node-bluetooth-hci-socket/src/node-bluetooth-hci-socket
> node-pre-gyp install --fallback-to-build
(...)
Release/obj.target/binding/src/BluetoothHciSocket.o: file not recognized: File truncated
collect2: error: ld returned 1 exit status
(...)
```
Or

```
rm: cannot remove './Release/.deps/Release/obj.target/binding/src/BluetoothHciSocket.o.d.raw': No such file or directory
(...)
make: *** [Release/obj.target/binding/src/BluetoothHciSocket.o] Error 1
```

Origin: https://github.com/abandonware/node-bluetooth-hci-socket/pulls
Relate-to: https://github.com/noble/node-bluetooth-hci-socket/pull/91
Change-Id: I34726c8adffc7c39f585f42da1f7d776c5761a17
Signed-off-by: Philippe Coval <p.coval@samsung.com>