### PR TITLE
Add one more support device

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ __WARNING:__ This will make the adapter unavailable in Windows Bluetooth setting
 | BCM920702 Bluetooth 4.0 | 0x0a5c | 0x21e8 |
 | BCM20702A0 Bluetooth 4.0 | 0x19ff | 0x0239 |
 | BCM20702A0 Bluetooth 4.0 | 0x0489 | 0xe07a |
+| BCM20702A0 Bluetooth 4.0 | 0x413c | 0x8143 |
 | CSR8510 A10 | 0x0a12 | 0x0001 |
 | Asus BT-400 | 0x0b05 | 0x17cb |
 | Intel Wireless Bluetooth 6235 | 0x8087 | 0x07da |

--- a/lib/usb.js
+++ b/lib/usb.js
@@ -15,6 +15,7 @@ var VENDOR_DEVICE_LIST = [
   {vid: 0x0CF3, pid: 0xE300 }, // Qualcomm Atheros QCA61x4
   {vid: 0x0a5c, pid: 0x21e8 }, // Broadcom BCM20702A0
   {vid: 0x19ff, pid: 0x0239 }, // Broadcom BCM20702A0
+  {vid: 0x413c, pid: 0x8143 }, // Broadcom BCM20702A0
   {vid: 0x0a12, pid: 0x0001 }, // CSR
   {vid: 0x0b05, pid: 0x17cb }, // ASUS BT400
   {vid: 0x8087, pid: 0x07da }, // Intel 6235


### PR DESCRIPTION
Fix for issue: https://github.com/noble/node-bluetooth-hci-socket/issues/119
Note: Support bluetooth device for Dell M4800
![Untitled](https://user-images.githubusercontent.com/8005041/69203899-24d2d780-0b78-11ea-81e1-d795006ead1c.png)
