### PR TITLE
reworked the connect workaround

### DIFF
--- a/lib/native.js
+++ b/lib/native.js
@@ -1,13 +1,28 @@
-var events = require('events');
+const events = require('events');
+const {BluetoothHciSocket} = require (`../build/Release/bluetooth_hci_socket.node`);
 
-var binary = require('@mapbox/node-pre-gyp');
-var path = require('path');
-var binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json')));
-var binding = require(binding_path);
-
-var BluetoothHciSocket = binding.BluetoothHciSocket;
 
 inherits(BluetoothHciSocket, events.EventEmitter);
+
+class BluetoothHciSocketWrapped extends BluetoothHciSocket {
+  constructor(...args) {
+    super(...args);
+  }
+
+  start(){
+    // Every minute perform a cleanup of connecting devices
+    this._timer = setInterval(()=>{
+      this.cleanup();
+    }, 60 * 1000);
+    this._timer.unref();
+    return super.start();
+  }
+
+  stop(){
+    clearInterval(this._timer);
+    return super.stop();
+  }
+}
 
 // extend prototype
 function inherits(target, source) {
@@ -16,4 +31,4 @@ function inherits(target, source) {
   }
 }
 
-module.exports = BluetoothHciSocket;
+module.exports = BluetoothHciSocketWrapped;

--- a/src/BluetoothHciSocket.h
+++ b/src/BluetoothHciSocket.h
@@ -2,10 +2,58 @@
 #define ___BLUETOOTH_HCI_SOCKET_H___
 
 #include <node.h>
-
+#include <map>
 #include <nan.h>
+#include <memory>
+
+// 1 minute in nanoseconds
+#define L2_CONNECT_TIMEOUT 60000000000
+
+typedef struct bdaddr_s {
+  uint8_t b[6];
+
+  bool operator<(const struct bdaddr_s& r) const {
+    for(int i = 0; i < 6; i++) {
+      if(b[i] >= r.b[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+} __attribute__((packed)) bdaddr_t;
+
+struct sockaddr_l2 {
+  sa_family_t    l2_family;
+  unsigned short l2_psm;
+  bdaddr_t       l2_bdaddr;
+  unsigned short l2_cid;
+  uint8_t        l2_bdaddr_type;
+};
+
+class BluetoothHciSocket;
+
+class BluetoothHciL2Socket {
+  public:
+  BluetoothHciL2Socket(BluetoothHciSocket* parent, unsigned char*, char, char*, char, uint64_t expires);
+  ~BluetoothHciL2Socket();
+  void disconnect();
+  void connect();
+  void expires(uint64_t expires);
+  uint64_t expires() const;
+  bool connected() const;
+
+
+  private:
+  int _socket;
+  BluetoothHciSocket* _parent;
+  uint64_t _expires; // or 0 if connected
+  struct sockaddr_l2 l2_src;
+  struct sockaddr_l2 l2_dst;
+};
 
 class BluetoothHciSocket : public node::ObjectWrap {
+  friend class BluetoothHciL2Socket;
 
 public:
   static NAN_MODULE_INIT(Init);
@@ -20,6 +68,7 @@ public:
   static NAN_METHOD(Start);
   static NAN_METHOD(Stop);
   static NAN_METHOD(Write);
+  static NAN_METHOD(Cleanup);
 
 private:
   BluetoothHciSocket();
@@ -41,6 +90,7 @@ private:
   int devIdFor(const int* devId, bool isUp);
   int kernelDisconnectWorkArounds(int length, char* data);
   bool kernelConnectWorkArounds(char* data, int length);
+  void setConnectionParameters(unsigned short connMinInterval, unsigned short connMaxInterval, unsigned short connLatency, unsigned short supervisionTimeout);
 
   static void PollCloseCallback(uv_poll_t* handle);
   static void PollCallback(uv_poll_t* handle, int status, int events);
@@ -54,6 +104,9 @@ private:
   uv_poll_t _pollHandle;
   uint8_t _address[6];
   uint8_t _addressType;
+  std::map<bdaddr_t, std::weak_ptr<BluetoothHciL2Socket>> _l2sockets_connected;
+  std::map<bdaddr_t, std::shared_ptr<BluetoothHciL2Socket>> _l2sockets_connecting;
+  std::map<unsigned short, std::shared_ptr<BluetoothHciL2Socket>> _l2sockets_handles;
 
   static Nan::Persistent<v8::FunctionTemplate> constructor_template;
 };


### PR DESCRIPTION
This version of the connect/disconnect workaround uses C++ to track ownership of the L2CAP handle and includes a expiration of connections that do not complete (hard coded 60s)

 - Fixes a fd leak on re-binding / binding close and a fd leak on re-use of a handle.
 - Includes support for out of order connect/disconnect events (previously worked only due to leak, my broadcom devices do this)