### PR TITLE
Allow easier rebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jshint": "^2.13.1"
   },
   "scripts": {
-    "install": "node-pre-gyp install --fallback-to-build",
+    "install": "node-pre-gyp install --fallback-to-build --update-binary",
     "test": "jshint lib/*.js && node test.js"
   },
   "binary": {


### PR DESCRIPTION
fixes #38

Without this change a "npm rebuild @abandonware/bluetooth-hci-socket@0.5.3-8" will just say "binary already there, pass other params (see issue). 

With this change it will recomile the package

