### PR TITLE
[fix] fix windows _usbDeviceInterface address

### DIFF
--- a/lib/usb.js
+++ b/lib/usb.js
@@ -83,6 +83,7 @@ BluetoothHciSocket.prototype.bindUser = function(devId, params) {
   this._usbDeviceInterface = this._usbDevice.interfaces[0];
 
   this._aclDataOutEndpoint = this._usbDeviceInterface.endpoint(0x02);
+  if (this._aclDataOutEndpoint === undefined) this._aclDataOutEndpoint = this._usbDeviceInterface.endpoint(0x01);
 
   this._hciEventEndpoint = this._usbDeviceInterface.endpoint(0x81);
   this._aclDataInEndpoint = this._usbDeviceInterface.endpoint(0x82);


### PR DESCRIPTION
I found one thing with Windows OS, in https://github.com/abandonware/node-bluetooth-hci-socket/blob/master/lib/usb.js . My windows has _aclDataOutEndpoint with 0x01 address. I made check for undefined descriptor and using 0x01 if it undefined.