### PR TITLE
update github actions

### DIFF
--- a/.github/workflows/fediverse-action.yml
+++ b/.github/workflows/fediverse-action.yml
@@ -6,7 +6,7 @@ jobs:
   post:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - id: log
         run: echo "::set-output name=message::$(git log --no-merges -1 --oneline)"
       - if: "contains(steps.log.outputs.message, 'Release ')"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,12 +16,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x, 16,x, 18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci

--- a/.github/workflows/nodepackage.yml
+++ b/.github/workflows/nodepackage.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Build Windows
         if: startsWith(runner.OS, 'windows') == true
         run: |
-          PATH=./node_modules/.bin:$PATH
           npm install --build-from-source
           ./node_modules/.bin/node-pre-gyp package
       - name: Test

--- a/.github/workflows/nodepackage.yml
+++ b/.github/workflows/nodepackage.yml
@@ -16,10 +16,13 @@ jobs:
         node_version: [
           10,
           12,
+          14,
+          16,
+          18
         ]
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}
       - name: Install dependencies

--- a/.github/workflows/nodepackage.yml
+++ b/.github/workflows/nodepackage.yml
@@ -10,15 +10,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        node_version: [
-          12,
-          14,
-          16,
-          18
-        ]
+      matrix:x
+        os: [ubuntu-latest, windows-2019]
+        node_version: [12, 14, 16, 18]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/nodepackage.yml
+++ b/.github/workflows/nodepackage.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:x
+      matrix:
         os: [ubuntu-latest, windows-2019]
         node_version: [12, 14, 16, 18]
     steps:

--- a/.github/workflows/nodepackage.yml
+++ b/.github/workflows/nodepackage.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         node_version: [
-          10,
           12,
           14,
           16,

--- a/.github/workflows/nodepackage.yml
+++ b/.github/workflows/nodepackage.yml
@@ -25,10 +25,17 @@ jobs:
         run: |
           sudo apt -qq update
           sudo apt install -y libudev-dev
-      - name: Build
+      - name: Build Linux
+        if: startsWith(runner.OS, 'windows') == false
         run: |
           export PATH=./node_modules/.bin:${PATH}
           npm install --build-from-source --node-gyp=$(which pangyp)
+          ./node_modules/.bin/node-pre-gyp package
+      - name: Build Windows
+        if: startsWith(runner.OS, 'windows') == true
+        run: |
+          PATH=./node_modules/.bin:$PATH
+          npm install --build-from-source
           ./node_modules/.bin/node-pre-gyp package
       - name: Test
         run: npm test

--- a/.github/workflows/nodepackage.yml
+++ b/.github/workflows/nodepackage.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
       - name: Install dependencies
+        if: startsWith(runner.OS, 'windows') == false
         run: |
           sudo apt -qq update
           sudo apt install -y libudev-dev

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@master
       with:
-        node-version: 10.0.0
+        node-version: 16.0.0
     - name: Publish if version has been updated
       uses: pascalgn/npm-publish-action@master
       with: # All of theses inputs are optional

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:node_version $env:platform
-  - ps: npm install -g node-gyp node-pre-gyp-github
+  - cmd: npm install -g node-gyp node-pre-gyp-github
   - ps: if ($env:appveyor_repo_tag -match "true" -and $env:appveyor_repo_tag_name -match '^v?[0-9]') { $publish_binary=1; }
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,10 @@ environment:
   GYP_MSVS_VERSION: 2013
 
   matrix:
-    - node_version: '10'
     - node_version: '12'
+    - node_version: '14'
+    - node_version: '16'
+    - node_version: '18'
 
 install:
   - ps: Install-Product node $env:node_version $env:platform


### PR DESCRIPTION
to include current nodejs versions for testing and packaging

Yes this is a small risk for failures on next release, but I think it makes a lot of sense to not use EOL versions of nodejs for testing only and such