### PR TITLE
Fix binary 404 error

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jshint": "^2.13.6"
   },
   "scripts": {
-    "install": "node-pre-gyp install --fallback-to-build --update-binary",
+    "install": "node-pre-gyp install --build-from-source",
     "test": "jshint lib/*.js && node test.js"
   },
   "binary": {


### PR DESCRIPTION
This fixes the following error:
```
node-pre-gyp ERR! install response status 404 Not Found on https://github.com/abandonware/node-bluetooth-hci-socket/releases/download/0.5.3-10/bluetooth_hci_socket-0.5.3-10-node-v108-linux-arm.tar.gz 
```

The default behavior now is to build from the source and not to attempt to download a non-existent binary.

This seems to have been broken for some time, even before the fork, as only a single release was created with https://github.com/noble/node-bluetooth-hci-socket/releases/tag/0.5.2.