### PR TITLE
Fix binary 404 error

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node": ">=10.0.0"
   },
   "scripts": {
-    "install": "node-pre-gyp install --fallback-to-build --update-binary",
+    "install": "node-pre-gyp install --build-from-source",
     "test": "jshint lib/*.js && node test.js"
   },
   "binary": {


### PR DESCRIPTION
See https://github.com/abandonware/node-bluetooth-hci-socket/pull/54#issuecomment-1951428435.

Could we possibly get a new release, @rzr?